### PR TITLE
Module scan

### DIFF
--- a/packages/core/src/entry-point.ts
+++ b/packages/core/src/entry-point.ts
@@ -87,12 +87,13 @@ export class ApplicationRunner {
     private runOption: RunOption<unknown>,
   ) {}
 
-  static runModule(entryModule: Constructor, runOption: RunOption) {
+  static runModule(entryModule: Constructor, runOption: Partial<RunOption> = {}) {
+    const actualRunOption = Object.assign({}, defaultRunOption, runOption);
     const moduleRoot = new ModuleRoot(provideBuiltin({
       entryModule,
       onShutdown,
     }));
-    const runner = new ApplicationRunner(process, moduleRoot, runOption);
+    const runner = new ApplicationRunner(process, moduleRoot, actualRunOption);
     function onShutdown() {
       runner.shutdown();
     }
@@ -214,13 +215,12 @@ export class ApplicationRunner {
 let entryPointCalled = false;
 
 export function EntryPoint(runOption: Partial<RunOption> = {}) {
-  const actualRunOption = Object.assign({}, defaultRunOption, runOption);
 
   return (moduleConstructor: Constructor) => {
     if (entryPointCalled) {
       throw new Error('only one entry point is allowed');
     }
     entryPointCalled = true;
-    process.nextTick(() => ApplicationRunner.runModule(moduleConstructor, actualRunOption));
+    process.nextTick(() => ApplicationRunner.runModule(moduleConstructor, runOption));
   };
 }

--- a/packages/core/src/entry-point.ts
+++ b/packages/core/src/entry-point.ts
@@ -57,10 +57,18 @@ export const defaultRunOption: RunOption = {
   onExit: (exitCode) => process.exit(exitCode),
 };
 
-function provideBuiltin(module: Constructor, option: {
+function provideBuiltin(option: {
+  entryModule: Constructor;
   onShutdown: () => void;
 }) {
-  @ModuleClass({requires: [createBuiltinModule(option), module]})
+  @ModuleClass({
+    requires: [
+      createBuiltinModule({
+        entryModule: EntryPointModule,
+        onShutdown: option.onShutdown,
+      }), option.entryModule,
+    ],
+  })
   class EntryPointModule {}
 
   return EntryPointModule;
@@ -79,8 +87,9 @@ export class ApplicationRunner {
     private runOption: RunOption<unknown>,
   ) {}
 
-  static runModule(moduleConstructor: Constructor, runOption: RunOption) {
-    const moduleRoot = new ModuleRoot(provideBuiltin(moduleConstructor, {
+  static runModule(entryModule: Constructor, runOption: RunOption) {
+    const moduleRoot = new ModuleRoot(provideBuiltin({
+      entryModule,
       onShutdown,
     }));
     const runner = new ApplicationRunner(process, moduleRoot, runOption);

--- a/packages/core/src/entry-point.ts
+++ b/packages/core/src/entry-point.ts
@@ -148,6 +148,7 @@ export class ApplicationRunner {
     if (this.isStopped) {
       return;
     }
+    this.isStopped = true;
 
     let promise = this.stopModuleRoot(option);
     if (option.timeout > 0) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export {BackgroundTaskQueue} from './builtin-module';
+export {BackgroundTaskQueue, ProcessManager} from './builtin-module';
 export * from './module';
 export * from './module-root';
 export * from './interfaces';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,5 +8,6 @@ export * from './decorators';
 export * from './interceptor';
 export {EntryPoint} from './entry-point';
 export * from './module-utility';
+export * from './module-scanner';
 export * from './utils';
 export * from './method-inject';

--- a/packages/core/src/module-instance.ts
+++ b/packages/core/src/module-instance.ts
@@ -1,7 +1,68 @@
-import {Container} from 'inversify';
+import {Container, ContainerModule, interfaces} from 'inversify';
 import {getModuleMetadata, ModuleMetadata} from './module';
 import {invokeMethod} from './method-inject';
-import {Constructor} from './interfaces';
+import {
+  BindingSpec,
+  ComponentFactory,
+  ComponentMetadata,
+  ComponentScope,
+  Constructor,
+  FactoryProvider,
+} from './interfaces';
+import {getComponentMetadata} from './component';
+
+function scopedBindingHelper<T>(
+  binding: interfaces.BindingInSyntax<T>,
+  scope: ComponentScope = ComponentScope.TRANSIENT,
+): interfaces.BindingWhenOnSyntax<T> {
+  switch (scope) {
+    case ComponentScope.SINGLETON:
+      return binding.inSingletonScope();
+    case ComponentScope.REQUEST:
+      return binding.inRequestScope();
+    default:
+      return binding.inTransientScope();
+  }
+}
+
+function bindingHelper<T>(spec: BindingSpec, from: () => interfaces.BindingInSyntax<T>) {
+  const result = scopedBindingHelper(from(), spec.scope);
+  if (spec.name) {
+    result.whenTargetNamed(spec.name);
+  }
+  if (spec.tags) {
+    for (const {key, value} of spec.tags) {
+      result.whenTargetTagged(key, value);
+    }
+  }
+}
+
+function createContainerModule(option: ModuleMetadata) {
+  const {components, factories, constants} = option;
+  return new ContainerModule((bind, unbind, isBound, rebind) => {
+    constants.forEach((constantProvider) => {
+      bind(constantProvider.provide).toConstantValue(constantProvider.value);
+    });
+
+    components.map(getComponentMetadata).map(async (metadata: ComponentMetadata<unknown>) => {
+      const {target, id = target} = metadata;
+      bindingHelper(metadata, () => bind(id).to(metadata.target));
+    });
+
+    factories.forEach((factoryProvider: FactoryProvider<unknown>) => {
+      const {provide, factory, scope, ...rest} = factoryProvider;
+      if (!isBound(factory)) {
+        bindingHelper({scope}, () => bind(factory).toSelf());
+      }
+      bindingHelper(rest, () =>
+        bind(provide).toDynamicValue((context: interfaces.Context) => {
+          const factoryInstance = context.container.get<ComponentFactory<unknown>>(factory);
+          return factoryInstance.build(context);
+        }),
+      );
+    });
+  });
+}
 
 /**
  * @private
@@ -13,6 +74,7 @@ export class ModuleInstance {
   private setupPromise?: Promise<void>;
   private destroyPromise?: Promise<void>;
   private moduleInstance?: any;
+  private containerModule: ContainerModule;
 
   constructor(
     readonly moduleClass: Constructor,
@@ -20,6 +82,7 @@ export class ModuleInstance {
     instanceMap: Map<Constructor, ModuleInstance> = new Map(),
   ) {
     this.moduleMetadata = getModuleMetadata(this.moduleClass);
+    this.containerModule = createContainerModule(this.moduleMetadata);
     if (typeof this.moduleMetadata === 'undefined') {
       throw new Error('Target is not a module');
     }
@@ -55,7 +118,7 @@ export class ModuleInstance {
       .bind(this.moduleClass)
       .toSelf()
       .inSingletonScope();
-    this.container.load(this.moduleMetadata.containerModule);
+    this.container.load(this.containerModule);
     this.moduleInstance = this.container.get<object>(this.moduleClass);
     for (const method of this.moduleMetadata.onModuleCreate) {
       if (typeof method === 'function') {
@@ -72,6 +135,6 @@ export class ModuleInstance {
         }
       }
     }
-    this.container.unload(this.moduleMetadata.containerModule);
+    this.container.unload(this.containerModule);
   }
 }

--- a/packages/core/src/module-instance.ts
+++ b/packages/core/src/module-instance.ts
@@ -9,7 +9,7 @@ import {Constructor} from './interfaces';
 export class ModuleInstance {
   public readonly dependencies: ModuleInstance[] = [];
   public referencedCounter = 0;
-  private readonly moduleMetadata: ModuleMetadata;
+  public readonly moduleMetadata: ModuleMetadata;
   private setupPromise?: Promise<void>;
   private destroyPromise?: Promise<void>;
   private moduleInstance?: any;

--- a/packages/core/src/module-root.ts
+++ b/packages/core/src/module-root.ts
@@ -31,16 +31,16 @@ export class ModuleRoot {
   }
 
   private async stopModule(moduleInstance: ModuleInstance) {
+    if (--moduleInstance.referencedCounter > 0) {
+      return;
+    }
     await moduleInstance.onDestroy();
     for (; ;) {
       const dependency = moduleInstance.dependencies.pop();
       if (!dependency) {
         return;
       }
-      dependency.referencedCounter--;
-      if (dependency.referencedCounter === 0) {
-        await this.stopModule(dependency);
-      }
+      await this.stopModule(dependency);
     }
   }
 }

--- a/packages/core/src/module-root.ts
+++ b/packages/core/src/module-root.ts
@@ -2,6 +2,9 @@ import {Container} from 'inversify';
 import {ModuleInstance} from './module-instance';
 import {Constructor} from './interfaces';
 
+/**
+ * @private
+ */
 export class ModuleRoot {
   readonly container: Container = new Container({skipBaseClassChecks: true});
   private readonly moduleInstanceMap: Map<Constructor, ModuleInstance> = new Map();
@@ -13,7 +16,6 @@ export class ModuleRoot {
   }
 
   public async start() {
-
     await this.startModule(this.entryModuleInstance);
   }
 

--- a/packages/core/src/module-scanner.ts
+++ b/packages/core/src/module-scanner.ts
@@ -1,0 +1,30 @@
+import {getModuleMetadata, ModuleMetadata} from './module';
+import {Constructor} from './interfaces';
+
+export class ModuleScanner {
+  public constructor(private entryModule: Constructor) {}
+
+  scanModule(callback: (metadata: ModuleMetadata) => void) {
+    const visitedModules = new Set<Constructor>();
+    const queue: Constructor[] = [this.entryModule];
+    for (; ;) {
+      const moduleToVisit = queue.pop();
+      if (typeof moduleToVisit === 'undefined') {
+        return;
+      }
+      if (visitedModules.has(moduleToVisit)) {
+        continue;
+      }
+      const metadata = getModuleMetadata(moduleToVisit);
+
+      for (const dependency of metadata.requires) {
+        if (!visitedModules.has(dependency)) {
+          queue.push(dependency);
+        }
+      }
+
+      callback(metadata);
+      visitedModules.add(moduleToVisit);
+    }
+  }
+}

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -24,7 +24,7 @@ export interface ModuleOption {
   /**
    * Components provided by this module
    */
-  components?: (Constructor | Class)[];
+  components?: (Constructor)[];
 
   /**
    * Factories provided by this module

--- a/packages/core/tests/entry-point.spec.ts
+++ b/packages/core/tests/entry-point.spec.ts
@@ -1,7 +1,8 @@
-import {EntryPoint, Inject, ModuleClass, OnModuleCreate, OnModuleDestroy} from '../src';
+import {EntryPoint, getModuleMetadata, Inject, ModuleClass, OnModuleCreate, OnModuleDestroy} from '../src';
 import {ProcessManager} from '../src/builtin-module';
 
 import '@sensejs/testing-utility/lib/mock-console';
+import {ModuleScanner} from '../src/module-scanner';
 
 /**
  * Because EntryPoint decorator is coupled to state of global process object,
@@ -19,6 +20,7 @@ test('EntryPoint decorator', async () => {
 
   jest.spyOn(process, 'exit').mockImplementation((exitCode: number = 0): never => {
     // throw an application to emulate process.exit, not finally block will be executed anyway
+    console.log('exit');
     stub(exitCode);
     return undefined as never;
     // throw new EmulateProcessExit('process exit');
@@ -28,7 +30,10 @@ test('EntryPoint decorator', async () => {
   @ModuleClass()
   class GlobalEntryPoint {
     @OnModuleCreate()
-    async onCreate(@Inject(ProcessManager) pm: ProcessManager) {
+    async onCreate(@Inject(ProcessManager) pm: ProcessManager, @Inject(ModuleScanner) moduleScanner: ModuleScanner) {
+      const stub = jest.fn();
+      moduleScanner.scanModule(stub);
+      expect(stub).toHaveBeenCalledWith(getModuleMetadata(GlobalEntryPoint));
       pm.shutdown();
     }
 

--- a/packages/core/tests/module-scanner.spec.ts
+++ b/packages/core/tests/module-scanner.spec.ts
@@ -1,0 +1,16 @@
+import {createModule, getModuleMetadata, ModuleRoot} from '../src';
+import {ModuleScanner} from '../src/module-scanner';
+
+test('ModuleScanner', () => {
+
+  const X = createModule();
+  const Y = createModule({requires: [X]});
+  const Z = createModule({requires: [X, Y]});
+  const moduleRoot = new ModuleScanner(Z);
+  const spy = jest.fn();
+  moduleRoot.scanModule(spy);
+  expect(spy).toHaveBeenCalledWith(getModuleMetadata(X));
+  expect(spy).toHaveBeenCalledWith(getModuleMetadata(Y));
+  expect(spy).toHaveBeenCalledWith(getModuleMetadata(Z));
+  expect(spy).toHaveBeenCalledTimes(3);
+});

--- a/packages/core/tests/module.spec.ts
+++ b/packages/core/tests/module.spec.ts
@@ -344,10 +344,12 @@ describe('Module Root', () => {
     }
 
     const moduleRoot = new ModuleRoot(Z);
+
     await moduleRoot.start();
     expect(zOnCreateSpy).toHaveBeenCalled();
     await moduleRoot.stop();
     expect(xOnDestroySpy).toHaveBeenCalled();
   });
+
 
 });

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -24,9 +24,9 @@
     "inversify": "^5.0.1",
     "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",
-    "lodash.uniq": "^4.5.0",
     "reflect-metadata": "^0.1.13",
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@sensejs/core": "workspace:*",
@@ -34,7 +34,7 @@
     "@types/koa-bodyparser": "^4.3.0",
     "@types/koa__cors": "^3.0.1",
     "@types/koa__router": "^8.0.2",
-    "@types/lodash.uniq": "^4.5.6",
+    "@types/lodash": "^4.14.149",
     "@types/node": "^12.12.29",
     "@types/supertest": "^2.0.8",
     "supertest": "^4.0.2",

--- a/packages/http/src/http-decorators.ts
+++ b/packages/http/src/http-decorators.ts
@@ -24,14 +24,21 @@ export interface ControllerMetadata {
   target: Constructor;
   prototype: object;
   interceptors: Constructor<HttpInterceptor>[];
+  label: Set<string | symbol>;
 }
 
 export interface ControllerOption {
+  /**
+   *
+   */
   interceptors?: Constructor<HttpInterceptor>[];
-  tags?: {
-    [tag: string]: unknown;
-    [tag: number]: unknown;
-  };
+
+  /**
+   * Label of controller
+   *
+   * @see HttpModuleOption
+   */
+  label?: (string | symbol)[] | Set<symbol | string>;
 }
 
 const noop: Transformer = (x) => x;
@@ -183,7 +190,8 @@ export function Controller(path: string, controllerOption: ControllerOption = {}
       target,
       path,
       prototype: target.prototype,
-      interceptors: controllerOption.interceptors || [],
+      interceptors: controllerOption.interceptors ?? [],
+      label: controllerOption.label instanceof Set ? controllerOption.label : new Set(controllerOption.label)
     });
   };
 }

--- a/packages/http/src/http-koa-integration.ts
+++ b/packages/http/src/http-koa-integration.ts
@@ -13,7 +13,7 @@ import {
   HttpRequest,
   HttpResponse,
 } from './http-abstract';
-import uniq from 'lodash.uniq';
+import {uniq} from 'lodash';
 import {ControllerMetadata, getRequestMappingMetadata, HttpMethod} from './http-decorators';
 
 interface MethodRouteSpec {

--- a/packages/http/tests/http-module.spec.ts
+++ b/packages/http/tests/http-module.spec.ts
@@ -29,7 +29,13 @@ test('HttpModule', async () => {
     }
   }
 
-  @Controller('/foo', {interceptors: [MockInterceptor]})
+  @Controller('/bar')
+  class BarController {
+    @GET('/')
+    bar() {}
+  }
+
+  @Controller('/foo', {interceptors: [MockInterceptor], label: ['foo']})
   class FooController {
     constructor(@inject(MyComponent) private myComponent: MyComponent) {}
 
@@ -42,6 +48,7 @@ test('HttpModule', async () => {
   const runPromise = ApplicationRunner.runModule(createHttpModule({
     requires: [createModule({components: [MyComponent, FooController]})],
     serverIdentifier,
+    matchLabel: ['foo'],
     httpOption: {
       listenPort: 3000,
       listenAddress: '0.0.0.0',
@@ -51,9 +58,7 @@ test('HttpModule', async () => {
       return undefined as never;
     },
   });
-
-  return Promise.all([
-    supertest('http://localhost:3000').get('/foo'),
-    runPromise,
-  ]);
+  await runPromise;
+  await supertest('http://localhost:3000').get('/bar').expect(404);
+  await supertest('http://localhost:3000').get('/foo').expect(200);
 });

--- a/packages/http/tests/http-module.spec.ts
+++ b/packages/http/tests/http-module.spec.ts
@@ -1,81 +1,59 @@
-import {Component, ModuleClass, ModuleRoot, OnModuleCreate} from '@sensejs/core';
-import {Container, inject} from 'inversify';
+import {Component, Inject, createModule} from '@sensejs/core';
+import {inject} from 'inversify';
 import supertest from 'supertest';
 import {Controller, createHttpModule, GET, HttpContext, HttpInterceptor} from '../src';
 import {Server} from 'http';
+import {ApplicationRunner} from '@sensejs/core/lib/entry-point';
+import {ProcessManager} from '@sensejs/core/lib/builtin-module';
 
-describe('HttpModule', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+test('HttpModule', async () => {
+  const serverIdentifier = Symbol();
+
+  class MockInterceptor extends HttpInterceptor {
+    intercept(context: HttpContext, next: () => Promise<void>): Promise<void> {
+      return next();
+    }
+  }
+
+  @Component()
+  class MyComponent {
+    constructor(
+      @Inject(ProcessManager) private processManager: ProcessManager,
+      @Inject(serverIdentifier) private httpServer: unknown,
+    ) {}
+
+    foo() {
+      expect(this.httpServer).toBeInstanceOf(Server);
+      this.processManager.shutdown();
+      return 'foo';
+    }
+  }
+
+  @Controller('/foo', {interceptors: [MockInterceptor]})
+  class FooController {
+    constructor(@inject(MyComponent) private myComponent: MyComponent) {}
+
+    @GET('/')
+    handleRequest() {
+      return this.myComponent.foo();
+    }
+  }
+
+  const runPromise = ApplicationRunner.runModule(createHttpModule({
+    requires: [createModule({components: [MyComponent, FooController]})],
+    serverIdentifier,
+    httpOption: {
+      listenPort: 3000,
+      listenAddress: '0.0.0.0',
+    },
+  }), {
+    onExit: () => {
+      return undefined as never;
+    },
   });
-  test('basic usage', async () => {
-    const stub = jest.fn();
 
-    class MockInterceptor extends HttpInterceptor {
-      intercept(context: HttpContext, next: () => Promise<void>): Promise<void> {
-        return next();
-      }
-    }
-
-    @Component()
-    class MyComponent {
-      foo() {
-        stub();
-        return 'foo';
-      }
-    }
-
-    @Controller('/foo', {interceptors: [MockInterceptor]})
-    class FooController {
-      constructor(@inject(MyComponent) private myComponent: MyComponent) {}
-
-      @GET('/')
-      handleRequest() {
-        return this.myComponent.foo();
-      }
-    }
-
-    const app = new ModuleRoot(createHttpModule({
-      components: [MyComponent, FooController],
-      httpOption: {
-        listenPort: 3000,
-        listenAddress: '0.0.0.0',
-      },
-    }));
-    await app.start();
-    await supertest('http://localhost:3000').get('/foo');
-    expect(stub).toHaveBeenCalled();
-    await app.stop();
-  });
-
-  test('could access http server with identifier', async () => {
-    const stub = jest.fn();
-    const serverIdentifier = Symbol();
-
-    const myHttpModule = createHttpModule({
-      serverIdentifier,
-      httpOption: {
-        listenPort: 0,
-        listenAddress: '0.0.0.0',
-      },
-    });
-
-    @ModuleClass({requires: [myHttpModule]})
-    class TestModule {
-      constructor(@inject(Container) private container: Container) {
-      }
-
-      @OnModuleCreate()
-      async onCreate() {
-        const containerServer = this.container.get(serverIdentifier);
-        stub(containerServer);
-      }
-    }
-
-    const app = new ModuleRoot(TestModule);
-    await app.start();
-    await app.stop();
-
-    expect(stub).toBeCalledWith(expect.any(Server));
-  });
+  return Promise.all([
+    supertest('http://localhost:3000').get('/foo'),
+    runPromise,
+  ]);
 });

--- a/packages/kafkajs/package.json
+++ b/packages/kafkajs/package.json
@@ -24,13 +24,15 @@
     "@sensejs/kafkajs-standalone": "workspace:*",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13",
-    "tslib": "^1.11.1"
+    "tslib": "^1.11.1",
+    "lodash": "^4.17.2"
   },
   "peerDependencies": {
     "kafkajs": "^1.12.0"
   },
   "devDependencies": {
     "@sensejs/testing-utility": "workspace:*",
+    "@types/lodash": "^4.14.149",
     "kafkajs": "^1.12.0",
     "rxjs": "^6.5.4",
     "ts-jest": "^25.2.1"

--- a/packages/kafkajs/src/consumer-decorators.ts
+++ b/packages/kafkajs/src/consumer-decorators.ts
@@ -15,6 +15,7 @@ export interface SubscribeTopicMetadata {
 
 export interface SubscribeTopicOption {
   topic?: string;
+  fromBeginning?: boolean;
 }
 
 export interface SubscribeControllerMetadata {

--- a/packages/kafkajs/src/consumer-decorators.ts
+++ b/packages/kafkajs/src/consumer-decorators.ts
@@ -21,10 +21,12 @@ export interface SubscribeTopicOption {
 export interface SubscribeControllerMetadata {
   interceptors: Constructor<RequestInterceptor>[];
   target: Class<{}>;
+  labels: Set<string | symbol>;
 }
 
 export interface SubscribeControllerOption {
   interceptors?: Constructor<RequestInterceptor>[];
+  labels?: (string | symbol)[] | Set<string | symbol>;
 }
 
 const SUBSCRIBE_TOPIC_METADATA_KEY = Symbol();
@@ -77,7 +79,12 @@ export function SubscribeTopic(option: InjectedSubscribeTopicDecoratorOption) {
 
 export function SubscribeController(option: SubscribeControllerOption = {}) {
   return (constructor: Constructor<{}>) => {
-    const metadata: SubscribeControllerMetadata = Object.assign({target: constructor, interceptors: []}, option);
+    const {interceptors = [], labels} = option;
+    const metadata: SubscribeControllerMetadata = {
+      target: constructor,
+      interceptors,
+      labels: new Set(labels),
+    };
     setSubscribeControllerMetadata(constructor, metadata);
     Component()(constructor);
   };

--- a/packages/kafkajs/src/consumer-module.ts
+++ b/packages/kafkajs/src/consumer-module.ts
@@ -18,6 +18,7 @@ import {
 import {Container} from 'inversify';
 import {KafkaReceivedMessage, MessageConsumer, MessageConsumerOption} from '@sensejs/kafkajs-standalone';
 import {ConsumerContext} from './consumer-context';
+import lodash from 'lodash';
 import {
   getSubscribeControllerMetadata,
   getSubscribeTopicMetadata,
@@ -30,6 +31,7 @@ export interface KafkaConsumerModuleOption extends ModuleOption {
   globalInterceptors?: Class<RequestInterceptor>[];
   messageConsumerOption?: Partial<MessageConsumerOption>;
   injectOptionFrom?: ServiceIdentifier;
+  matchLabels?: (string | symbol)[] | Set<string | symbol>;
 }
 
 function mergeConnectOption(
@@ -72,7 +74,11 @@ function scanSubscriber(
           if (!controllerMetadata) {
             return;
           }
-          this.scanPrototypeMethod(component, controllerMetadata);
+          const matchLabels = new Set(option.matchLabels);
+          const intersectedLabels = lodash.intersection([...matchLabels], [...controllerMetadata.labels]);
+          if (intersectedLabels.length === matchLabels.size) {
+            this.scanPrototypeMethod(component, controllerMetadata);
+          }
         });
       });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,10 +153,12 @@ importers:
       '@sensejs/core': 'link:../core'
       '@sensejs/kafkajs-standalone': 'link:../kafkajs-standalone'
       inversify: 5.0.1
+      lodash: 4.17.15
       reflect-metadata: 0.1.13
       tslib: 1.11.1
     devDependencies:
       '@sensejs/testing-utility': 'link:../../tools/testing-utility'
+      '@types/lodash': 4.14.149
       kafkajs: 1.12.0
       rxjs: 6.5.4
       ts-jest: 25.2.1
@@ -164,8 +166,10 @@ importers:
       '@sensejs/core': 'workspace:*'
       '@sensejs/kafkajs-standalone': 'workspace:*'
       '@sensejs/testing-utility': 'workspace:*'
+      '@types/lodash': ^4.14.149
       inversify: ^5.0.1
       kafkajs: ^1.12.0
+      lodash: ^4.17.2
       reflect-metadata: ^0.1.13
       rxjs: ^6.5.4
       ts-jest: ^25.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
       inversify: 5.0.1
       koa: 2.11.0
       koa-bodyparser: 4.2.1
-      lodash.uniq: 4.5.0
+      lodash: 4.17.15
       reflect-metadata: 0.1.13
       tslib: 1.11.1
     devDependencies:
@@ -124,7 +124,7 @@ importers:
       '@types/koa-bodyparser': 4.3.0
       '@types/koa__cors': 3.0.1
       '@types/koa__router': 8.0.2
-      '@types/lodash.uniq': 4.5.6
+      '@types/lodash': 4.14.149
       '@types/node': 12.12.29
       '@types/supertest': 2.0.8
       supertest: 4.0.2
@@ -137,13 +137,13 @@ importers:
       '@types/koa-bodyparser': ^4.3.0
       '@types/koa__cors': ^3.0.1
       '@types/koa__router': ^8.0.2
-      '@types/lodash.uniq': ^4.5.6
+      '@types/lodash': ^4.14.149
       '@types/node': ^12.12.29
       '@types/supertest': ^2.0.8
       inversify: ^5.0.1
       koa: ^2.11.0
       koa-bodyparser: ^4.2.1
-      lodash.uniq: ^4.5.0
+      lodash: ^4.17.15
       reflect-metadata: ^0.1.13
       supertest: ^4.0.2
       ts-jest: ^25.2.1
@@ -959,12 +959,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-3ZWfVAEcErHrZA31fWUC2YyZyAgoG4eKtQPy2XwBzdSpQealxjL7GcEEtGY925qPPs1wurW59qDl0KuRB39rrw==
-  /@types/lodash.uniq/4.5.6:
-    dependencies:
-      '@types/lodash': 4.14.149
-    dev: true
-    resolution:
-      integrity: sha512-XHNMXBtiwsWZstZMyxOYjr0e8YYWv0RgPlzIHblTuwBBiWo2MzWVaTBihtBpslb5BglgAWIeBv69qt1+RTRW1A==
   /@types/lodash/4.14.149:
     dev: true
     resolution:
@@ -4209,12 +4203,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  /lodash.uniq/4.5.0:
-    dev: false
-    resolution:
-      integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
   /lodash/4.17.15:
-    dev: true
     resolution:
       integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
   /log-symbols/1.0.2:


### PR DESCRIPTION
Add a module scanner in core package, so that integration module like http and kafka can scan the whole module tree to find controllers, or message subscribers.