### PR TITLE
Update  Typescript to v5, reorganize tsconfigs

### DIFF
--- a/.changeset/nervous-paws-camp.md
+++ b/.changeset/nervous-paws-camp.md
@@ -1,0 +1,16 @@
+---
+'@sensejs/kafkajs-zstd-support': patch
+'@sensejs/kafkajs-standalone': patch
+'@sensejs/http-koa-platform': patch
+'@sensejs/testing-utility': patch
+'@sensejs/http-common': patch
+'@sensejs/container': patch
+'@sensejs/kafkajs': patch
+'@sensejs/testing': patch
+'@sensejs/utility': patch
+'@sensejs/config': patch
+'@sensejs/logger': patch
+'@sensejs/core': patch
+---
+
+reorgnize tsconfigs

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.baseline.json"
   },
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "overrides": [

--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,7 @@ packages/**/lib/
 examples/**/lib/
 tools/**/lib/
 /lib/
-dist-types
+dist-dts/
 temp/
 # typeorm test use temp.db for sqlite3 driver
 temp.*

--- a/jest.base-config.cjs
+++ b/jest.base-config.cjs
@@ -10,7 +10,7 @@ module.exports = {
   testEnvironment: 'node',
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
-      tsconfig: '<rootDir>/tsconfig.test.json',
+      tsconfig: '<rootDir>/tsconfig.json',
       diagnostics: 'pretty',
       useESM: true
     }],

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "source-map-support": "^0.5.21",
     "sqlite3": "^5.1.6",
     "supertest": "^6.3.3",
-    "ts-jest": "^29.0.5",
+    "ts-jest": "^29.1.0",
     "ts-node": "^10.9.1",
     "tslib": "^2.5.0",
     "typescript": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "tslib": "^2.5.0",
-    "typescript": "^4.9.5"
+    "typescript": "^5.0.3"
   },
   "scripts": {
     "test": "node  --experimental-vm-modules --experimental-specifier-resolution=node  ./node_modules/jest/bin/jest.js",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/*",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "author": "LAN Xingcan",
   "license": "ISC",

--- a/packages/config/src/tsconfig.json
+++ b/packages/config/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/config/tsconfig.build-cjs.json
+++ b/packages/config/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/config/tsconfig.build-dts.json
+++ b/packages/config/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/config/tsconfig.build-esm.json
+++ b/packages/config/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/config/tsconfig.test.json
+++ b/packages/config/tsconfig.test.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.test",
-  "include": [
-    "tests/**/*.ts",
-    "src/**/*.ts"
-  ]
-}

--- a/packages/container/package.json
+++ b/packages/container/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/container/src/tsconfig.json
+++ b/packages/container/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/container/tsconfig.build-cjs.json
+++ b/packages/container/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/container/tsconfig.build-dts.json
+++ b/packages/container/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/container/tsconfig.build-esm.json
+++ b/packages/container/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/container/tsconfig.json
+++ b/packages/container/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,8 +1,8 @@
-import {Class, Transformer} from './interfaces.js';
-import {Inject, InjectionDecorator, Optional} from './decorators.js';
-import {consoleLogger, DecoratorBuilder, Logger} from '@sensejs/utility';
+import type {Class, Transformer} from './interfaces.js';
+import {Inject, type InjectionDecorator, Optional} from './decorators.js';
+import {consoleLogger, DecoratorBuilder, type Logger} from '@sensejs/utility';
 
-export {consoleLogger, Logger} from '@sensejs/utility';
+export {consoleLogger, type Logger} from '@sensejs/utility';
 
 export abstract class LoggerBuilder {
   abstract build(loggerLabel: string): Logger;

--- a/packages/core/src/method-invoker.ts
+++ b/packages/core/src/method-invoker.ts
@@ -1,5 +1,5 @@
-import {InvokeResult, ResolveSession} from '@sensejs/container';
-import {Constructor} from './interfaces.js';
+import {type InvokeResult, ResolveSession} from '@sensejs/container';
+import type {Constructor} from './interfaces.js';
 
 /**
  * Invoke method with arguments from container

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -1,4 +1,4 @@
-import {ConstantProvider, Constructor, FactoryProvider} from './interfaces.js';
+import type {ConstantProvider, Constructor, FactoryProvider} from './interfaces.js';
 import {Injectable, InjectScope, Scope} from '@sensejs/container';
 import {deprecate} from './utils/index.js';
 

--- a/packages/core/src/tsconfig.json
+++ b/packages/core/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/core/tsconfig.build-cjs.json
+++ b/packages/core/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/core/tsconfig.build-dts.json
+++ b/packages/core/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/core/tsconfig.build-esm.json
+++ b/packages/core/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/http-common/package.json
+++ b/packages/http-common/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http-common/src/tsconfig.json
+++ b/packages/http-common/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/http-common/tsconfig.build-cjs.json
+++ b/packages/http-common/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/http-common/tsconfig.build-dts.json
+++ b/packages/http-common/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/http-common/tsconfig.build-esm.json
+++ b/packages/http-common/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/http-common/tsconfig.json
+++ b/packages/http-common/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/http-koa-platform/package.json
+++ b/packages/http-koa-platform/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
-    "import": "./dist-esm/lib/index.js",
+    "types": "./dist-dts/index.d.ts",
+    "module": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/http-koa-platform/src/tsconfig.json
+++ b/packages/http-koa-platform/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/http-koa-platform/tsconfig.build-cjs.json
+++ b/packages/http-koa-platform/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/http-koa-platform/tsconfig.build-dts.json
+++ b/packages/http-koa-platform/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/http-koa-platform/tsconfig.build-esm.json
+++ b/packages/http-koa-platform/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/http-koa-platform/tsconfig.json
+++ b/packages/http-koa-platform/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/kafkajs-standalone/package.json
+++ b/packages/kafkajs-standalone/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kafkajs-standalone/src/tsconfig.json
+++ b/packages/kafkajs-standalone/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/kafkajs-standalone/tsconfig.build-cjs.json
+++ b/packages/kafkajs-standalone/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/kafkajs-standalone/tsconfig.build-dts.json
+++ b/packages/kafkajs-standalone/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/kafkajs-standalone/tsconfig.build-esm.json
+++ b/packages/kafkajs-standalone/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/kafkajs-standalone/tsconfig.json
+++ b/packages/kafkajs-standalone/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/kafkajs-zstd-support/package.json
+++ b/packages/kafkajs-zstd-support/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kafkajs-zstd-support/src/tsconfig.json
+++ b/packages/kafkajs-zstd-support/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/kafkajs-zstd-support/tsconfig.build-cjs.json
+++ b/packages/kafkajs-zstd-support/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/kafkajs-zstd-support/tsconfig.build-dts.json
+++ b/packages/kafkajs-zstd-support/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/kafkajs-zstd-support/tsconfig.build-esm.json
+++ b/packages/kafkajs-zstd-support/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/kafkajs-zstd-support/tsconfig.json
+++ b/packages/kafkajs-zstd-support/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/kafkajs/package.json
+++ b/packages/kafkajs/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/kafkajs/src/tsconfig.json
+++ b/packages/kafkajs/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/kafkajs/tsconfig.build-cjs.json
+++ b/packages/kafkajs/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/kafkajs/tsconfig.build-dts.json
+++ b/packages/kafkajs/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/kafkajs/tsconfig.build-esm.json
+++ b/packages/kafkajs/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/kafkajs/tsconfig.json
+++ b/packages/kafkajs/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/logger/src/tsconfig.json
+++ b/packages/logger/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/logger/tsconfig.build-cjs.json
+++ b/packages/logger/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/logger/tsconfig.build-dts.json
+++ b/packages/logger/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/logger/tsconfig.build-esm.json
+++ b/packages/logger/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/testing/dist-esm/package.json
+++ b/packages/testing/dist-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/testing/src/tsconfig.json
+++ b/packages/testing/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/testing/tsconfig.build-cjs.json
+++ b/packages/testing/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/testing/tsconfig.build-dts.json
+++ b/packages/testing/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/testing/tsconfig.build-esm.json
+++ b/packages/testing/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -5,22 +5,24 @@
   "files": [
     "dist-cjs/**/!(*.tsbuildinfo)",
     "dist-esm/**/!(*.tsbuildinfo)",
+    "dist-dts/**/!(*.tsbuildinfo)",
     "src/**/*.ts",
     "README.md"
   ],
   "type": "module",
-  "types": "./dist-esm/lib/index.d.ts",
+  "types": "./dist-dts/lib/index.d.ts",
   "main": "./dist-cjs/lib/index.js",
   "module": "./dist-esm/lib/index.js",
   "exports": {
+    "types": "./dist-dts/index.d.ts",
     "import": "./dist-esm/lib/index.js",
     "require": "./dist-cjs/lib/index.js"
   },
   "scripts": {
     "test": "jest",
-    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json",
+    "build": "tsc -p tsconfig.build-cjs.json && tsc -p tsconfig.build-esm.json && tsc -p tsconfig.build-dts.json",
     "prepublishOnly": "npm run clean && npm run build",
-    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib"
+    "clean": "rm -rf ./dist-esm/lib dist-cjs/lib dist-dts"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utility/src/tsconfig.json
+++ b/packages/utility/src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.baseline",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./**/*.spec.ts",
+    "./**/*.test.ts"
+  ]
+}

--- a/packages/utility/tsconfig.build-cjs.json
+++ b/packages/utility/tsconfig.build-cjs.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "CommonJS",
     "outDir": "dist-cjs/lib",
-    "declarationDir": "dist-cjs/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/utility/tsconfig.build-dts.json
+++ b/packages/utility/tsconfig.build-dts.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./src/tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist-dts",
+    "declarationDir": "dist-dts",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "paths": {}
+  }
+}

--- a/packages/utility/tsconfig.build-esm.json
+++ b/packages/utility/tsconfig.build-esm.json
@@ -1,11 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./src/tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
     "module": "ESNext",
     "outDir": "dist-esm/lib",
-    "declarationDir": "dist-esm/lib",
-    "baseUrl": ".",
     "paths": {}
   }
 }

--- a/packages/utility/tsconfig.json
+++ b/packages/utility/tsconfig.json
@@ -1,13 +1,7 @@
 {
-  "extends": "../../tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
+  "extends": "../../tsconfig.test",
   "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "lib"
+    "./src/**/*.ts",
+    "./tests/**/*.ts"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,10 +39,10 @@ importers:
         version: 2.0.12
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.55.0
-        version: 5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.36.0)(typescript@4.9.5)
+        version: 5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.36.0)(typescript@5.0.3)
       '@typescript-eslint/parser':
         specifier: ^5.55.0
-        version: 5.55.0(eslint@8.36.0)(typescript@4.9.5)
+        version: 5.55.0(eslint@8.36.0)(typescript@5.0.3)
       enhanced-resolve:
         specifier: ^5.12.0
         version: 5.12.0
@@ -93,16 +93,16 @@ importers:
         version: 6.3.3
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@5.0.3)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@14.18.38)(typescript@4.9.5)
+        version: 10.9.1(@types/node@14.18.38)(typescript@5.0.3)
       tslib:
         specifier: ^2.5.0
         version: 2.5.0
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.0.3
+        version: 5.0.3
 
   examples/demo-app:
     dependencies:
@@ -4440,7 +4440,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.36.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.55.0(@typescript-eslint/parser@5.55.0)(eslint@8.36.0)(typescript@5.0.3):
     resolution: {integrity: sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4452,23 +4452,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.55.0(eslint@8.36.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.55.0(eslint@8.36.0)(typescript@5.0.3)
       '@typescript-eslint/scope-manager': 5.55.0
-      '@typescript-eslint/type-utils': 5.55.0(eslint@8.36.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.55.0(eslint@8.36.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.55.0(eslint@8.36.0)(typescript@5.0.3)
+      '@typescript-eslint/utils': 5.55.0(eslint@8.36.0)(typescript@5.0.3)
       debug: 4.3.4
       eslint: 8.36.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.0.3)
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.55.0(eslint@8.36.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.55.0(eslint@8.36.0)(typescript@5.0.3):
     resolution: {integrity: sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4480,10 +4480,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.3)
       debug: 4.3.4
       eslint: 8.36.0
-      typescript: 4.9.5
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4496,7 +4496,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.55.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.55.0(eslint@8.36.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.55.0(eslint@8.36.0)(typescript@5.0.3):
     resolution: {integrity: sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4506,12 +4506,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.55.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.55.0(eslint@8.36.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.3)
+      '@typescript-eslint/utils': 5.55.0(eslint@8.36.0)(typescript@5.0.3)
       debug: 4.3.4
       eslint: 8.36.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.0.3)
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4521,7 +4521,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.55.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.55.0(typescript@5.0.3):
     resolution: {integrity: sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4536,13 +4536,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.0.3)
+      typescript: 5.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.55.0(eslint@8.36.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.55.0(eslint@8.36.0)(typescript@5.0.3):
     resolution: {integrity: sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4553,7 +4553,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.55.0
       '@typescript-eslint/types': 5.55.0
-      '@typescript-eslint/typescript-estree': 5.55.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.55.0(typescript@5.0.3)
       eslint: 8.36.0
       eslint-scope: 5.1.1
       semver: 7.3.8
@@ -8633,7 +8633,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@types/node@14.18.38)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@14.18.38)(typescript@5.0.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12626,7 +12626,7 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: true
 
-  /ts-jest@29.0.5(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@4.9.5):
+  /ts-jest@29.0.5(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@5.0.3):
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -12657,7 +12657,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.3.8
-      typescript: 4.9.5
+      typescript: 5.0.3
       yargs-parser: 21.1.1
     dev: true
 
@@ -12692,6 +12692,37 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /ts-node@10.9.1(@types/node@14.18.38)(typescript@5.0.3):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 14.18.38
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: true
@@ -12704,14 +12735,14 @@ packages:
     engines: {node: '>=0.6.x'}
     dev: false
 
-  /tsutils@3.21.0(typescript@4.9.5):
+  /tsutils@3.21.0(typescript@5.0.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.0.3
     dev: true
 
   /tty-table@4.2.1:
@@ -12810,6 +12841,12 @@ packages:
   /typescript@4.9.5:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript@5.0.3:
+    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
+    engines: {node: '>=12.20'}
     hasBin: true
     dev: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^6.3.3
         version: 6.3.3
       ts-jest:
-        specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@5.0.3)
+        specifier: ^29.1.0
+        version: 29.1.0(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@5.0.3)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@14.18.38)(typescript@5.0.3)
@@ -12626,8 +12626,8 @@ packages:
     resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
     dev: true
 
-  /ts-jest@29.0.5(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@5.0.3):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
+  /ts-jest@29.1.0(@babel/core@7.21.3)(@jest/types@29.5.0)(jest@29.5.0)(typescript@5.0.3):
+    resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -12636,7 +12636,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3'
+      typescript: '>=4.3 <6'
     peerDependenciesMeta:
       '@babel/core':
         optional: true

--- a/tools/testing-utility/tsconfig.json
+++ b/tools/testing-utility/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig",
+  "extends": "../../tsconfig.baseline",
   "compilerOptions": {
     "noEmit": false,
     "outDir": "lib",

--- a/tsconfig.baseline.json
+++ b/tsconfig.baseline.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "strictFunctionTypes": true,
     "strictBindCallApply": true,
@@ -13,8 +13,6 @@
     "noEmitHelpers": true,
     "importHelpers": true,
     "sourceMap": true,
-    "declaration": true,
-    "declarationMap": true,
     "lib": ["es2018"],
     "types": ["node", "reflect-metadata"],
     "skipLibCheck": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,9 +1,7 @@
 {
-  "extends": "./tsconfig",
+  "extends": "./tsconfig.baseline",
   "compilerOptions": {
     "types": ["node", "jest", "reflect-metadata"],
-    "noEmitHelpers": false,
-    "importHelpers": false,
     "module": "ESNext",
     "incremental": false,
     "paths": {


### PR DESCRIPTION
Due to Typescript Language Server does not support multiple tsconfig yet(https://github.com/microsoft/TypeScript/issues/33094). After upgrading to Typescript v5, all decorators in test files are treated as ECMA-Stage3 decorator, instead of the experimental legacy one. It can be overcome by using the following structure:
```
+--src
| |
| + tsconfig.json # Use for editor support for files in ./src
+ tsconfig.json # Use for editor support for both ./src and ./tests
```
Furthermore, a new type of tsconfig named `tsconfig.build-dts.json` will be added to each sub-project, and declarations will be emit into `dist-dts` folder, `tsconfig.build-esm.json` and `tsconfig.cjs.json` will emit only `.js` files.