### PR TITLE
refactor: redesign the shape of MultipartFileEntry

### DIFF
--- a/.changeset/soft-spoons-joke.md
+++ b/.changeset/soft-spoons-joke.md
@@ -1,0 +1,11 @@
+---
+'@sensejs/multipart': patch
+---
+
+Redesign the shape of MultipartFileEntry.
+
+It now has a new function member `body()` that returns a Readable;
+for MultipartFileInMemoryStorage an additional content field is
+presented for accessing the buffer directly, while for
+MultipartFileDiskStorage, the content field is deprecated and
+will be removed in 0.12

--- a/packages/multipart-s3-adaptor/src/index.ts
+++ b/packages/multipart-s3-adaptor/src/index.ts
@@ -119,7 +119,7 @@ export class S3StorageAdaptor extends RemoteStorageAdaptor<string, S3MultipartUp
     this.s3Client.destroy();
   }
 
-  createReadStream(key: string): NodeJS.ReadableStream {
+  createReadStream(key: string): Readable {
     const result = new stream.PassThrough();
     this.s3Client.getObject({Bucket: this.s3Bucket, Key: key}).then(
       (response) => {

--- a/packages/multipart-s3-adaptor/tests/index.spec.ts
+++ b/packages/multipart-s3-adaptor/tests/index.spec.ts
@@ -89,7 +89,7 @@ describe('MultipartS3Storage', () => {
 
       const downloadBuffer = [];
 
-      for await (const chunk of result.content()) {
+      for await (const chunk of result.body()) {
         downloadBuffer.push(Buffer.from(chunk));
       }
       expect(Buffer.concat(downloadBuffer)).toEqual(content);
@@ -117,7 +117,7 @@ describe('MultipartS3Storage', () => {
       });
       const downloadBuffer = [];
 
-      for await (const chunk of result.content()) {
+      for await (const chunk of result.body()) {
         downloadBuffer.push(Buffer.from(chunk));
       }
 

--- a/packages/multipart/src/disk-storage.ts
+++ b/packages/multipart/src/disk-storage.ts
@@ -7,6 +7,13 @@ import stream from 'stream';
 import {promisify} from 'util';
 import {MultipartLimitExceededError} from './error.js';
 
+export interface LegacyMultipartFieldEntry extends MultipartFileEntry {
+  /**
+   * @deprecated Use `body` instead
+   */
+  content: NodeJS.ReadableStream;
+}
+
 export interface DiskStorageOption extends MultipartFileStorageOption {
   /**
    * The directory to store the uploaded files
@@ -19,7 +26,7 @@ export interface DiskStorageOption extends MultipartFileStorageOption {
   removeFilesOnClean?: boolean;
 }
 
-export class MultipartFileDiskStorage extends MultipartFileStorage<NodeJS.ReadableStream> {
+export class MultipartFileDiskStorage extends MultipartFileStorage<LegacyMultipartFieldEntry> {
   static readonly fileSizeLimit = 32 * 1024 * 1024;
   static readonly fileCountLimit = 128;
   readonly fileSizeLimit: number;
@@ -42,7 +49,7 @@ export class MultipartFileDiskStorage extends MultipartFileStorage<NodeJS.Readab
     name: string,
     file: NodeJS.ReadableStream,
     info: MultipartFileInfo,
-  ): Promise<MultipartFileEntry<NodeJS.ReadableStream>> {
+  ): Promise<LegacyMultipartFieldEntry> {
     if (this.fileCount++ >= this.fileCountLimit) {
       throw new MultipartLimitExceededError('Too many files');
     }
@@ -91,6 +98,7 @@ export class MultipartFileDiskStorage extends MultipartFileStorage<NodeJS.Readab
         name,
         filename: info.filename,
         content: readable,
+        body: () => readable,
         size,
         mimeType: info.mimeType,
         transferEncoding: info.transferEncoding,

--- a/packages/multipart/src/in-memory-storage.ts
+++ b/packages/multipart/src/in-memory-storage.ts
@@ -1,10 +1,14 @@
 import {MultipartFileEntry, MultipartFileInfo, MultipartFileStorage, MultipartFileStorageOption} from './types.js';
 import {MultipartLimitExceededError} from './error.js';
+import {Readable} from 'stream';
 
+export interface InMemoryMultipartFileEntry extends MultipartFileEntry {
+  content: Buffer;
+}
 /**
  *
  */
-export class MultipartFileInMemoryStorage extends MultipartFileStorage<Buffer> {
+export class MultipartFileInMemoryStorage extends MultipartFileStorage<InMemoryMultipartFileEntry> {
   static readonly fileSizeLimit = 32 * 1024 * 1024;
   static readonly fileCountLimit = 1;
   readonly fileSizeLimit: number;
@@ -27,18 +31,18 @@ export class MultipartFileInMemoryStorage extends MultipartFileStorage<Buffer> {
   }
 
   async clean() {
-    // for an in-memory storage, there is nothing to clean
+    // for an in-memory storage, there is nothing needs to be cleaned
   }
 
   saveMultipartFile(
     name: string,
     file: NodeJS.ReadableStream,
     info: MultipartFileInfo,
-  ): Promise<MultipartFileEntry<Buffer>> {
+  ): Promise<InMemoryMultipartFileEntry> {
     if (this.fileCount++ >= this.fileCountLimit) {
       return Promise.reject(new MultipartLimitExceededError('Too many files'));
     }
-    return new Promise<MultipartFileEntry<Buffer>>((resolve, reject) => {
+    return new Promise<InMemoryMultipartFileEntry>((resolve, reject) => {
       let lastBufferCapacity = 16;
       let buffer: Buffer = Buffer.alloc(Math.min(this.fileSizeLimit, lastBufferCapacity * 2));
       let size = 0;
@@ -66,6 +70,7 @@ export class MultipartFileInMemoryStorage extends MultipartFileStorage<Buffer> {
           name,
           filename: info.filename,
           content: buffer,
+          body: () => Readable.from([buffer]),
           size: size,
           mimeType: info.mimeType,
           transferEncoding: info.transferEncoding,

--- a/packages/multipart/src/index.ts
+++ b/packages/multipart/src/index.ts
@@ -3,8 +3,8 @@ import stream from 'stream';
 import type http from 'http';
 import {AsyncIterableQueue} from '@sensejs/utility';
 import {InvalidMultipartBodyError, MultipartLimitExceededError} from './error.js';
-import {MultipartEntry, MultipartFileStorage} from './types.js';
-import {MultipartFileInMemoryStorage} from './in-memory-storage.js';
+import {MultipartEntry, MultipartFileEntry, MultipartFileStorage} from './types.js';
+import {InMemoryMultipartFileEntry, MultipartFileInMemoryStorage} from './in-memory-storage.js';
 
 export * from './error.js';
 export * from './in-memory-storage.js';
@@ -89,8 +89,8 @@ export class Multipart {
     return [multipart, cleanup];
   }
 
-  read(): Promise<Record<string, MultipartEntry<any>>>;
-  read<Content>(handler: MultipartFileStorage<Content>): Promise<Record<string, MultipartEntry<any>>>;
+  read(): Promise<Record<string, MultipartEntry<MultipartFileEntry>>>;
+  read<F extends MultipartFileEntry>(handler: MultipartFileStorage<F>): Promise<Record<string, MultipartEntry<F>>>;
 
   async read(handler?: MultipartFileStorage<any>): Promise<Record<string, MultipartEntry<any>>> {
     const result: Record<string, MultipartEntry<any>> = {};
@@ -100,8 +100,8 @@ export class Multipart {
     return result;
   }
 
-  entries(): AsyncIterable<MultipartEntry<Buffer>>;
-  entries<Content>(handler: MultipartFileStorage<Content>): AsyncIterable<MultipartEntry<Content>>;
+  entries(): AsyncIterable<MultipartEntry<InMemoryMultipartFileEntry>>;
+  entries<F extends MultipartFileEntry>(handler: MultipartFileStorage<F>): AsyncIterable<MultipartEntry<F>>;
 
   // read(): Promise<AsyncIterator<MultipartEntry<Buffer>>>;
   entries(multipartFileHandler?: MultipartFileStorage<any>): AsyncIterable<MultipartEntry<any>> {

--- a/packages/multipart/src/remote-storage-adaptor.ts
+++ b/packages/multipart/src/remote-storage-adaptor.ts
@@ -80,7 +80,7 @@ export abstract class RemoteStorageAdaptor<F extends {}, P extends {}, C extends
    */
   abstract abortPartitionedUpload(pud: P): Promise<void>;
 
-  abstract createReadStream(file: F): NodeJS.ReadableStream;
+  abstract createReadStream(file: F): Readable;
 
   abstract cleanup(): Promise<void>;
 }

--- a/packages/multipart/src/remote-storage.ts
+++ b/packages/multipart/src/remote-storage.ts
@@ -16,7 +16,7 @@ import {MultipartLimitExceededError} from './error.js';
  * just perform a simple upload, otherwise we have to perform a partitioned upload.
  *
  */
-export class MultipartFileRemoteStorage implements MultipartFileStorage<() => NodeJS.ReadableStream> {
+export class MultipartFileRemoteStorage implements MultipartFileStorage {
   public readonly fileCountLimit: number;
   public readonly fileSizeLimit: number;
   private readonly adaptor: RemoteStorageAdaptor<any, any, any>;
@@ -42,12 +42,12 @@ export class MultipartFileRemoteStorage implements MultipartFileStorage<() => No
     name: string,
     file: NodeJS.ReadableStream,
     info: MultipartFileInfo,
-  ): Promise<MultipartFileEntry<() => NodeJS.ReadableStream>> {
+  ): Promise<MultipartFileEntry> {
     if (this.fileCount >= this.fileCountLimit) {
       throw new MultipartLimitExceededError('File count limit exceeded');
     }
     this.fileCount += 1;
-    return new Promise<MultipartFileEntry<() => NodeJS.ReadableStream>>((resolve, reject) => {
+    return new Promise<MultipartFileEntry>((resolve, reject) => {
       const writable = new UploadStream(this.adaptor, name, info, resolve);
       pipeline(file, writable, (e) => {
         if (e) {

--- a/packages/multipart/src/types.ts
+++ b/packages/multipart/src/types.ts
@@ -1,9 +1,9 @@
-import type busboy from '@fastify/busboy';
+import type {Readable} from 'stream';
 
 /**
  * A multipart file entry
  */
-export interface MultipartFileEntry<Content> {
+export interface MultipartFileEntry {
   type: 'file';
   /**
    * The name of the file field
@@ -15,12 +15,7 @@ export interface MultipartFileEntry<Content> {
    */
   filename: string;
 
-  /**
-   * The file content, the type of it depends on the implementation.
-   * For the default implementation of in-memory handler, it's a buffer,
-   * For the default implementation of file handler, it's a ReadableStream to the file.
-   */
-  content: Content;
+  body: () => Readable;
 
   transferEncoding: string;
 
@@ -53,18 +48,14 @@ export interface MultipartFileInfo {
   transferEncoding: string;
 }
 
-export type MultipartEntry<Content> = MultipartFileEntry<Content> | MultipartFieldEntry;
+export type MultipartEntry<File extends MultipartFileEntry = MultipartFileEntry> = File | MultipartFieldEntry;
 
-export abstract class MultipartFileStorage<Content> {
+export abstract class MultipartFileStorage<File extends MultipartFileEntry = MultipartFileEntry> {
   abstract readonly fileSizeLimit: number;
 
   abstract readonly fileCountLimit: number;
 
-  abstract saveMultipartFile(
-    name: string,
-    file: NodeJS.ReadableStream,
-    info: MultipartFileInfo,
-  ): Promise<MultipartFileEntry<Content>>;
+  abstract saveMultipartFile(name: string, file: NodeJS.ReadableStream, info: MultipartFileInfo): Promise<File>;
 
   abstract clean(): Promise<void>;
 }

--- a/packages/multipart/src/upload-stream.ts
+++ b/packages/multipart/src/upload-stream.ts
@@ -88,7 +88,7 @@ export class UploadStream<F extends {}, P extends {}, C extends ChecksumCalculat
     private readonly adaptor: RemoteStorageAdaptor<F, P, C>,
     private name: string,
     private info: MultipartFileInfo,
-    private resolve: (file: MultipartFileEntry<() => NodeJS.ReadableStream>) => void,
+    private resolve: (file: MultipartFileEntry) => void,
   ) {
     super();
     this.buffer = Buffer.allocUnsafe(Math.max(adaptor.simpleUploadSizeLimit, adaptor.partitionedUploadSizeLimit));
@@ -155,7 +155,7 @@ export class UploadStream<F extends {}, P extends {}, C extends ChecksumCalculat
             type: 'file',
             name: this.name,
             size: this.fileSize,
-            content: () => this.adaptor.createReadStream(result),
+            body: () => this.adaptor.createReadStream(result),
             mimeType: this.info.mimeType,
             filename: this.info.filename,
             transferEncoding: this.info.transferEncoding,
@@ -171,7 +171,7 @@ export class UploadStream<F extends {}, P extends {}, C extends ChecksumCalculat
         this.resolve({
           name: this.name,
           size: this.fileSize,
-          content: () => this.adaptor.createReadStream(result),
+          body: () => this.adaptor.createReadStream(result),
           mimeType: this.info.mimeType,
           filename: this.info.filename,
           transferEncoding: this.info.transferEncoding,

--- a/packages/multipart/tests/common.ts
+++ b/packages/multipart/tests/common.ts
@@ -1,0 +1,19 @@
+import {expect} from '@jest/globals';
+import {Readable} from 'stream';
+
+export async function readStreamToBuffer(readable: Readable, size: number) {
+  let offset = 0;
+  const content = Buffer.allocUnsafe(size);
+  await new Promise<void>((resolve, reject) => {
+    readable.on('data', (chunk) => {
+      chunk.copy(content, offset);
+      offset += chunk.length;
+    });
+    readable.on('end', () => {
+      expect(offset).toBe(size);
+      resolve();
+    });
+    readable.on('error', reject);
+  });
+  return content;
+}

--- a/packages/multipart/tests/in-memory-storage.spec.ts
+++ b/packages/multipart/tests/in-memory-storage.spec.ts
@@ -2,26 +2,32 @@ import {MultipartFileInMemoryStorage, MultipartLimitExceededError} from '../src/
 import {describe, test} from '@jest/globals';
 import {Readable} from 'stream';
 import {AsyncIterableQueue} from '@sensejs/utility';
+import {readStreamToBuffer} from './common.js';
 
 describe('MultipartFileInMemoryStorage', () => {
   test('should works', async () => {
     const storage = new MultipartFileInMemoryStorage();
-    expect(
-      await storage.saveMultipartFile('file', Readable.from([Buffer.from('Hello '), Buffer.from('World!')]), {
+    const result = await storage.saveMultipartFile(
+      'file',
+      Readable.from([Buffer.from('Hello '), Buffer.from('World!')]),
+      {
         filename: 'test.txt',
         transferEncoding: '7bit',
         mimeType: 'text/plain',
-      }),
-    ).toEqual(
+      },
+    );
+    expect(result).toEqual(
       expect.objectContaining({
         type: 'file',
         name: 'file',
         filename: 'test.txt',
-        content: Buffer.from('Hello World!'),
+        // content: Buffer.from('Hello World!'),
         size: 12,
         mimeType: 'text/plain',
       }),
     );
+    expect(result.content).toEqual(Buffer.from('Hello World!'));
+    expect(await readStreamToBuffer(result.body(), result.size)).toEqual(Buffer.from('Hello World!'));
   });
 
   test('large input', async () => {

--- a/packages/multipart/tests/remote-storage.spec.ts
+++ b/packages/multipart/tests/remote-storage.spec.ts
@@ -56,7 +56,7 @@ class MockRemoteStorageAdaptor extends RemoteStorageAdaptor<string, fsp.FileHand
     }
   }
 
-  createReadStream(file: string): NodeJS.ReadableStream {
+  createReadStream(file: string): Readable {
     const stream = fs.createReadStream(file);
     this.openedFiles.add(stream);
     return stream;
@@ -128,7 +128,7 @@ describe('RemoteStorage', () => {
       return storage.saveMultipartFile('file2', Readable.from(input), fileInfo);
     }).rejects.toBeInstanceOf(MultipartLimitExceededError);
     const chunks: Buffer[] = [];
-    for await (const chunk of result.content()) {
+    for await (const chunk of result.body()) {
       chunks.push(Buffer.from(chunk));
     }
     expect(Buffer.concat(chunks)).toEqual(content);

--- a/packages/multipart/tests/upload-stream.spec.ts
+++ b/packages/multipart/tests/upload-stream.spec.ts
@@ -38,7 +38,7 @@ async function pipeUploadStream(
     mimeType: 'text/plain',
     transferEncoding: '7bit',
   };
-  return new Promise<MultipartFileEntry<() => NodeJS.ReadableStream>>((resolve, reject) => {
+  return new Promise<MultipartFileEntry>((resolve, reject) => {
     pipeline(input, new UploadStream(adaptor, 'foo.txt', mockFileInfo, resolve), (err) => {
       if (err) {
         reject(err);
@@ -127,7 +127,7 @@ class MockRemoteStorageAdaptor extends RemoteStorageAdaptor<string, string, Noop
     this.partitionUploads.delete(partition);
   }
 
-  createReadStream(fileKey: string): NodeJS.ReadableStream {
+  createReadStream(fileKey: string): Readable {
     const buffers = this.files.get(fileKey);
     if (!buffers) {
       throw new Error('Invalid file key');
@@ -197,7 +197,7 @@ describe('UploadStream', () => {
       size: 30,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content.toString()).toBe('helloworld12345678901234567890');
   });
 
@@ -218,7 +218,7 @@ describe('UploadStream', () => {
       size: 50,
     });
 
-    expect(await readStreamAsBuffer(result.content())).toEqual(resultBuffer);
+    expect(await readStreamAsBuffer(result.body())).toEqual(resultBuffer);
 
     const slowStream = Readable.from(toSlowStreamChunks(buffers));
     const slowConsumeAdaptor = new MockRemoteStorageAdaptor(45, 40, 1);
@@ -231,7 +231,7 @@ describe('UploadStream', () => {
       size: 50,
     });
 
-    expect(await readStreamAsBuffer(slowResult.content())).toEqual(resultBuffer);
+    expect(await readStreamAsBuffer(slowResult.body())).toEqual(resultBuffer);
   });
 
   test('simple upload error', async () => {
@@ -286,7 +286,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -301,7 +301,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -316,7 +316,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -331,7 +331,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -346,7 +346,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -361,7 +361,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -376,7 +376,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
   test('large multipart upload, slow input and consume, maxSimpleUploadSize=50, maxPartitionedUploadSize=24', async () => {
@@ -390,7 +390,7 @@ describe('UploadStream', () => {
       size: Buffer.concat(buffers).length,
     });
 
-    const content = await readStreamAsBuffer(result.content());
+    const content = await readStreamAsBuffer(result.body());
     expect(content).toEqual(Buffer.concat(buffers));
   });
 
@@ -407,7 +407,7 @@ describe('UploadStream', () => {
         size: Buffer.concat(buffers).length,
       });
 
-      const content = await readStreamAsBuffer(result.content());
+      const content = await readStreamAsBuffer(result.body());
       expect(content).toEqual(Buffer.concat(buffers));
     }
   });


### PR DESCRIPTION
It now has a new function member `body()` that returns a Readable; for MultipartFileInMemoryStorage an additional content field is presented for accessing the buffer directly, while for MultipartFileDiskStorage, the content field is deprecated and will be removed in 0.12